### PR TITLE
Switching to webpack to make UMD build. Fixes #79.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+	presets: ['latest'],
+	plugins: [
+		'transform-object-rest-spread',
+		['transform-runtime', {polyfill: false, regenerator: true}],
+	],
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: node_js
 node_js:
   - "6.0.0"
 script:
+  - npm run jspm-install
   - npm run test:travis

--- a/bin/build-code
+++ b/bin/build-code
@@ -1,9 +1,5 @@
 #!/bin/bash -e
 
-./node_modules/jspm/jspm.js build \
-	single-spa \
-	lib/single-spa.js \
-	--format umd \
-	--global-name singleSpa \
-	--source-map-contents \
+./node_modules/webpack/bin/webpack.js \
+	--config webpack.config.js \
 	"$@"

--- a/jspm.config.js
+++ b/jspm.config.js
@@ -663,7 +663,6 @@ SystemJS.config({
     "child_process": "npm:jspm-nodelibs-child_process@0.2.0",
     "constants": "npm:jspm-nodelibs-constants@0.2.0",
     "crypto": "npm:jspm-nodelibs-crypto@0.2.0",
-    "custom-event": "npm:custom-event@1.0.0",
     "events": "npm:jspm-nodelibs-events@0.2.0",
     "fs": "npm:jspm-nodelibs-fs@0.2.0",
     "os": "npm:jspm-nodelibs-os@0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
-{  "name": "single-spa",
+{
+  "name": "single-spa",
   "version": "3.2.1",
   "description": "Multiple applications, one page",
   "main": "lib/single-spa.js",
   "scripts": {
     "jspm-install": "jspm install",
     "build": "./bin/build-code",
-    "watch": "./bin/build-code -dw",
+    "watch": "./bin/build-code -w",
     "build:test": "./bin/build-tests",
-    "prepublish": "npm run jspm-install && npm run build",
+    "prepublish": "npm run build",
     "clean": "rm -rf lib",
     "test": "npm run build:test && npm run build && karma start --single-run",
     "test:debug": "npm run build:test && npm run build && karma start",
-    "test:travis": "npm run build:test && npm run build && karma start karma-saucelabs.conf.js --single-run",
-    "build:canopy": "npm run build && rm -rf ../spalpatine/jspm_packages/npm/single-spa@3.1.0 && rsync -av . ../spalpatine/jspm_packages/npm/single-spa@3.1.0 --exclude node_modules --exclude .git --exclude --spec --exclude examples --exclude jspm_packages --exclude spec --exclude docs && cd ../spalpatine && npm run build-common-deps && cd ../single-spa"
+    "test:travis": "npm run build:test && npm run build && karma start karma-saucelabs.conf.js --single-run"
   },
   "repository": "https://github.com/CanopyTax/single-spa",
   "keywords": [
@@ -25,11 +25,17 @@
   ],
   "author": "Joel Denning",
   "license": "MIT",
-  "dependencies": {},
+  "dependencies": {
+    "custom-event": "^1.0.1"
+  },
   "devDependencies": {
     "babel-cli": "^6.14.0",
     "babel-loader": "^6.2.5",
+    "babel-plugin-transform-async-to-generator": "^6.16.0",
+    "babel-plugin-transform-object-rest-spread": "^6.19.0",
+    "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-latest": "^6.14.0",
+    "babel-regenerator-runtime": "^6.5.0",
     "concurrently": "^2.2.0",
     "jasmine": "^2.4.1",
     "jspm": "^0.17.0-beta.28",
@@ -37,7 +43,7 @@
     "karma-chrome-launcher": "^1.0.1",
     "karma-jasmine": "^1.0.2",
     "karma-sauce-launcher": "^1.0.0",
-    "webpack": "^2.1.0-beta.21"
+    "webpack": "^2.1.0-beta.27"
   },
   "ignore": [
     "examples"
@@ -48,9 +54,7 @@
   "jspm": {
     "name": "single-spa",
     "main": "lib/single-spa.js",
-    "dependencies": {
-      "custom-event": "^1.0.0"
-    },
+    "dependencies": {},
     "devDependencies": {
       "babel-preset-es0015": "babel-preset-es2015@^6.13.2",
       "babel-preset-stage-1": "^6.13.0",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,9 @@
   "devDependencies": {
     "babel-cli": "^6.14.0",
     "babel-loader": "^6.2.5",
-    "babel-plugin-transform-async-to-generator": "^6.16.0",
     "babel-plugin-transform-object-rest-spread": "^6.19.0",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-latest": "^6.14.0",
-    "babel-regenerator-runtime": "^6.5.0",
     "concurrently": "^2.2.0",
     "jasmine": "^2.4.1",
     "jspm": "^0.17.0-beta.28",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,37 @@
+var path = require('path');
+var webpack = require('webpack');
+
+module.exports = {
+	entry: [
+		__dirname + '/src/single-spa.js',
+	],
+	output: {
+		path: __dirname + '/lib',
+		filename: 'single-spa.js',
+		library: 'singleSpa',
+		libraryTarget: 'umd',
+		umdNamedDefine: true,
+	},
+	devtool: 'source-map',
+	resolve: {
+		modules: [
+			"node_modules",
+			path.resolve(__dirname),
+		],
+	},
+	module: {
+		loaders: [
+			{
+				test: /\.js$/,
+				exclude: /(node_modules|bower_components)/,
+				loader: 'babel-loader',
+			},
+		],
+	},
+	plugins: [
+		new webpack.optimize.UglifyJsPlugin({
+			compress: true,
+			test: /\.js($|\?)/i,
+		}),
+	],
+}


### PR DESCRIPTION
See #79. This will be unnecessary once https://github.com/systemjs/builder/pull/735 is merged in and released, but @TheMcMurder is waiting on this so I decided to switch to webpack for the time being. This makes it so that you can use single-spa in the following ways:

- npm install single-spa
- jspm install npm:single-spa
- <script src="/single-spa.js"></script>

That is much the same as before. The difference, though, is that if you `import * as singleSpa from 'single-spa'` inside of a webpack project, it will now succeed instead of fail. Note that I have tested this in the canopy app, in an dummy webpack app, and with a script tag. All appear to work fine.