### PR TITLE
Throwing useful error when a loading function does not return a promise

### DIFF
--- a/spec/child-apps/invalid-load-function/invalid-load-function.spec.js
+++ b/spec/child-apps/invalid-load-function/invalid-load-function.spec.js
@@ -1,0 +1,112 @@
+export default function() {
+	describe(`invalid-load-function`, () => {
+		beforeEach(() => {
+			location.hash = "#";
+		});
+
+		afterEach(() => {
+			location.hash = "#";
+		});
+
+		it('Dies if the load function returns nothing', done => {
+			function loadFunction() {
+				// return nothing
+			}
+			singleSpa.declareChildApplication('./invalid-load-function.app.js', loadFunction, location => location.hash === "#invalid-load-function");
+
+			let applicationBrokenCalled = false;
+			window.addEventListener("single-spa:application-broken", applicationBroken);
+
+			function applicationBroken(evt) {
+				applicationBrokenCalled = true;
+				expect(evt.detail.appName).toBe('./invalid-load-function.app.js');
+				expect(evt.detail.err.message.indexOf('single-spa loading function did not return a promise. Check the second argument to declareChildApplication')).toBeGreaterThan(-1);
+			}
+
+			location.hash = "#invalid-load-function";
+
+			singleSpa
+			.triggerAppChange()
+			.then(() => {
+				window.removeEventListener("single-spa:application-broken", applicationBroken);
+				expect(applicationBrokenCalled).toBe(true);
+				expect(singleSpa.getAppStatus('./invalid-load-function.app.js')).toBe(singleSpa.SKIP_BECAUSE_BROKEN);
+				done();
+			})
+			.catch(err => {
+				window.removeEventListener("single-spa:application-broken", applicationBroken);
+				fail(err);
+				done();
+			})
+		});
+
+		it('Dies if the load function returns a function instead of a promise', done => {
+			function loadFunction() {
+				return function() {
+					return Promise.resolve();
+				}
+			}
+			singleSpa.declareChildApplication('./invalid-load-function.app.js', loadFunction, location => location.hash === "#invalid-load-function");
+
+			let applicationBrokenCalled = false;
+			window.addEventListener("single-spa:application-broken", applicationBroken);
+
+			function applicationBroken(evt) {
+				applicationBrokenCalled = true;
+				expect(evt.detail.appName).toBe('./invalid-load-function.app.js');
+				expect(evt.detail.err.message.indexOf('single-spa loading function did not return a promise. Check the second argument to declareChildApplication')).toBeGreaterThan(-1);
+			}
+
+			location.hash = "#invalid-load-function";
+
+			singleSpa
+			.triggerAppChange()
+			.then(() => {
+				window.removeEventListener("single-spa:application-broken", applicationBroken);
+				expect(applicationBrokenCalled).toBe(true);
+				expect(singleSpa.getAppStatus('./invalid-load-function.app.js')).toBe(singleSpa.SKIP_BECAUSE_BROKEN);
+				done();
+			})
+			.catch(err => {
+				window.removeEventListener("single-spa:application-broken", applicationBroken);
+				fail(err);
+				done();
+			})
+		});
+
+		it('Dies if the load function returns a non-thenable object', done => {
+			function loadFunction() {
+				return {
+					things: `that aren't valid`,
+					catch: 'khalifa',
+				};
+			}
+			singleSpa.declareChildApplication('./invalid-load-function.app.js', loadFunction, location => location.hash === "#invalid-load-function");
+
+			let applicationBrokenCalled = false;
+			window.addEventListener("single-spa:application-broken", applicationBroken);
+
+			function applicationBroken(evt) {
+				applicationBrokenCalled = true;
+				expect(evt.detail.appName).toBe('./invalid-load-function.app.js');
+				expect(evt.detail.err.message.indexOf('single-spa loading function did not return a promise. Check the second argument to declareChildApplication')).toBeGreaterThan(-1);
+			}
+
+			location.hash = "#invalid-load-function";
+
+			singleSpa
+			.triggerAppChange()
+			.then(() => {
+				window.removeEventListener("single-spa:application-broken", applicationBroken);
+				expect(applicationBrokenCalled).toBe(true);
+				expect(singleSpa.getAppStatus('./invalid-load-function.app.js')).toBe(singleSpa.SKIP_BECAUSE_BROKEN);
+				done();
+			})
+			.catch(err => {
+				window.removeEventListener("single-spa:application-broken", applicationBroken);
+				fail(err);
+				done();
+			})
+		});
+	});
+}

--- a/spec/root-apps/systemjs.spec.js
+++ b/spec/root-apps/systemjs.spec.js
@@ -20,6 +20,7 @@ import unmountTimesOutDies from 'spec/child-apps/unmount-times-out-dies/unmount-
 import usesLoader from 'spec/child-apps/uses-loader/uses-loader.spec.js';
 import navigateToUrlTests from 'spec/apis/navigate-to-url.spec.js';
 import returnsNonNativePromise from 'spec/child-apps/returns-non-native-promise/returns-non-native-promise.spec.js';
+import invalidLoadFunction from 'spec/child-apps/invalid-load-function/invalid-load-function.spec.js';
 import { notStartedEventListeners, yesStartedEventListeners } from 'spec/apis/event-listeners.spec.js';
 
 describe("SystemJS loader :", () => {
@@ -70,6 +71,7 @@ describe("SystemJS loader :", () => {
 			unmountTimesOutDies();
 			usesLoader();
 			returnsNonNativePromise();
+			invalidLoadFunction();
 		});
 
 		describe(`apis :`, () => {

--- a/spec/root-apps/webpack2.spec.js
+++ b/spec/root-apps/webpack2.spec.js
@@ -18,6 +18,7 @@ import unmountRejects from '../child-apps/unmount-rejects/unmount-rejects.spec.j
 import unmountTimesOutDies from '../child-apps/unmount-times-out-dies/unmount-times-out-dies.spec.js';
 import unmountTimesOut from '../child-apps/unmount-times-out/unmount-times-out.spec.js';
 import returnsNonNativePromise from '../child-apps/returns-non-native-promise/returns-non-native-promise.spec.js';
+import invalidLoadFunction from '../child-apps/invalid-load-function/invalid-load-function.spec.js';
 
 describe('webpack2 loader', () => {
 	beforeAll(done => {
@@ -51,6 +52,7 @@ describe('webpack2 loader', () => {
 		unmountTimesOutDies();
 		unmountTimesOut();
 		returnsNonNativePromise();
+		invalidLoadFunction();
 	});
 });
 

--- a/src/child-applications/child-app-errors.js
+++ b/src/child-applications/child-app-errors.js
@@ -3,7 +3,7 @@ import CustomEvent from 'custom-event';
 export function handleChildAppError(err, childApp) {
 	const transformedErr = transformErr(err, childApp);
 
-	window.dispatchEvent(new CustomEvent("single-spa:application-broken", {detail: {appName: childApp.name}}));
+	window.dispatchEvent(new CustomEvent("single-spa:application-broken", {detail: {appName: childApp.name, err: transformedErr}}));
 
 	if (window.SINGLE_SPA_TESTING) {
 		console.error(transformedErr);


### PR DESCRIPTION
While debugging with @TheMcMurder, we realized that if you do not return a Promise from inside of your loading function that single-spa just hangs waiting for the promise to resolve even though it's not even a promise. No useful error messaging....nothing.

So this pull request fixes that so that there is a useful error message when a loading function returns anything but a Promise/thenable.