### PR TITLE
Calling lifecyles with props. Fixes #91

### DIFF
--- a/docs/child-applications.md
+++ b/docs/child-applications.md
@@ -23,7 +23,7 @@ A lifecycle function is a function or array of functions that single-spa will ca
 Lifecycle functions are exported from the main entry point of a child application.
 
 Notes:
-- Lifecycle functions are not called with any arguments.
+- Lifecycle functions are called with a `props` argument, which is an object with a `childAppName` string.
 - Implementing `bootstrap`, `mount`, and `unmount` is required. But implementing `unload` is optional.
 - Each lifecycle function must either return a `Promise` or be an `async function`.
 - If an array of functions is exported (instead of just one function), the functions will be called
@@ -48,9 +48,9 @@ For example:
 console.log("The child application has been loaded!");
 System.import('./path-to-some-file-i-want-to-execute');
 
-export async function bootstrap() {...}
-export async function mount() {...}
-export async function unmount() {...}
+export async function bootstrap(props) {...}
+export async function mount(props) {...}
+export async function unmount(props) {...}
 ```
 
 ### bootstrap
@@ -58,7 +58,7 @@ This lifecycle function will be called once, right before the child application 
 mounted for the first time.
 
 ```js
-export function bootstrap() {
+export function bootstrap(props) {
   return new Promise((resolve, reject) => {
     resolve();
   })
@@ -67,12 +67,12 @@ export function bootstrap() {
 
 ```js
 export const bootstrap = [
-  function firstThing() {
+  function firstThing(props) {
     return new Promise((resolve, reject) => {
       resolve();
     })
   },
-  function secondThing() {
+  function secondThing(props) {
     return new Promise((resolve, reject) => {
       resolve();
     })
@@ -89,7 +89,7 @@ events (such as `hashchange` and `popstate`) will **not** trigger more calls to 
 instead should be handled by the childl application itself.
 
 ```js
-export function mount() {
+export function mount(props) {
   return new Promise((resolve, reject) => {
     resolve();
   })
@@ -98,12 +98,12 @@ export function mount() {
 
 ```js
 export const mount = [
-  function firstThing() {
+  function firstThing(props) {
     return new Promise((resolve, reject) => {
       resolve();
     })
   },
-  function secondThing() {
+  function secondThing(props) {
     return new Promise((resolve, reject) => {
       resolve();
     })
@@ -118,7 +118,7 @@ called, this function should clean up all DOM elements, DOM event listeners, lea
 observable subscriptions, etc. that were created at any point when the child application was mounted.
 
 ```js
-export function unmount() {
+export function unmount(props) {
   return new Promise((resolve, reject) => {
     resolve();
   })
@@ -127,12 +127,12 @@ export function unmount() {
 
 ```js
 export const unmount = [
-  function firstThing() {
+  function firstThing(props) {
     return new Promise((resolve, reject) => {
       resolve();
     })
   },
-  function secondThing() {
+  function secondThing(props) {
     return new Promise((resolve, reject) => {
       resolve();
     })
@@ -152,7 +152,7 @@ The motivation for `unload` was to implement the hot-loading of entire child app
 scenarios as well when you want to re-bootstrap applications, but perform some logic before applications are re-bootstrapped.
 
 ```js
-export function unload() {
+export function unload(props) {
   return new Promise((resolve, reject) => {
     console.log('unloading');
     resolve();
@@ -162,12 +162,12 @@ export function unload() {
 
 ```js
 export const unload = [
-  function firstThing() {
+  function firstThing(props) {
     return new Promise((resolve, reject) => {
       resolve();
     })
   },
-  function secondThing() {
+  function secondThing(props) {
     return new Promise((resolve, reject) => {
       resolve();
     })
@@ -183,9 +183,9 @@ from the main entry point of the child application. Example:
 ```js
 // app-1.main-entry.js
 
-export function bootstrap() {...}
-export function mount() {...}
-export function unmount() {...}
+export function bootstrap(props) {...}
+export function mount(props) {...}
+export function unmount(props) {...}
 
 export const timeouts = {
   bootstrap: {

--- a/spec/child-apps/lifecycle-props/lifecycle-props.app.js
+++ b/spec/child-apps/lifecycle-props/lifecycle-props.app.js
@@ -1,0 +1,42 @@
+let bootstrapProps, mountProps, unmountProps, unloadProps;
+
+export function bootstrap(props) {
+	bootstrapProps = props;
+	return Promise.resolve();
+}
+
+export function mount(props) {
+	mountProps = props;
+	return Promise.resolve();
+}
+
+export function unmount(props) {
+	unmountProps = props;
+	return Promise.resolve();
+}
+
+export function unload(props) {
+	unloadProps = props;
+	return Promise.resolve();
+}
+
+export function getBootstrapProps() {
+	return bootstrapProps;
+}
+
+export function getMountProps() {
+	return mountProps;
+}
+
+export function getUnmountProps() {
+	return unmountProps;
+}
+
+export function getUnloadProps() {
+	return unloadProps;
+}
+
+export function reset() {
+	console.log('resetting')
+	bootstrapProps = mountProps = unmountProps = unloadProps = null;
+}

--- a/spec/child-apps/lifecycle-props/lifecycle-props.spec.js
+++ b/spec/child-apps/lifecycle-props/lifecycle-props.spec.js
@@ -1,0 +1,52 @@
+const activeHash = `#lifecycle-props`;
+
+export default function() {
+	describe(`lifecycle-props app`, () => {
+		let childApp;
+
+		beforeAll(() => {
+			console.log('declaring child app')
+			singleSpa.declareChildApplication('lifecycle-props', () => System.import('./lifecycle-props.app.js'), location => location.hash === activeHash);
+		});
+
+		beforeEach(done => {
+			System
+			.import('./lifecycle-props.app.js')
+			.then(app => childApp = app)
+			.then(app => app.reset())
+			.then(done)
+			.catch(err => {
+				fail(err);
+				done();
+			});
+		});
+
+		it(`is given the correct props for each lifecycle function`, done => {
+			// This mounts the app
+			window.location.hash = activeHash;
+
+			singleSpa
+			.triggerAppChange()
+			.then(() => {
+				// This unmounts the app
+				window.location.hash = `#/no-app`;
+				return singleSpa.triggerAppChange();
+			})
+			.then(() => {
+				return singleSpa.unloadChildApplication('lifecycle-props');
+			})
+			.then(() => {
+				expect(childApp.getBootstrapProps()).toEqual({childAppName: 'lifecycle-props'});
+				expect(childApp.getMountProps()).toEqual({childAppName: 'lifecycle-props'});
+				expect(childApp.getUnmountProps()).toEqual({childAppName: 'lifecycle-props'});
+				expect(childApp.getUnloadProps()).toEqual({childAppName: 'lifecycle-props'});
+
+				done();
+			})
+			.catch(err => {
+				fail(err);
+				done();
+			});
+		});
+	});
+}

--- a/spec/root-apps/systemjs.spec.js
+++ b/spec/root-apps/systemjs.spec.js
@@ -23,6 +23,7 @@ import returnsNonNativePromise from 'spec/child-apps/returns-non-native-promise/
 import invalidLoadFunction from 'spec/child-apps/invalid-load-function/invalid-load-function.spec.js';
 import happyUnload from 'spec/child-apps/happy-unload/happy-unload.spec.js';
 import invalidUnload from 'spec/child-apps/invalid-unload/invalid-unload.spec.js';
+import lifecyleProps from 'spec/child-apps/lifecycle-props/lifecycle-props.spec.js';
 import { notStartedEventListeners, yesStartedEventListeners } from 'spec/apis/event-listeners.spec.js';
 
 describe("SystemJS loader :", () => {
@@ -76,6 +77,7 @@ describe("SystemJS loader :", () => {
 			invalidLoadFunction();
 			happyUnload();
 			invalidUnload();
+			lifecyleProps();
 		});
 
 		describe(`apis :`, () => {

--- a/spec/root-apps/webpack2.spec.js
+++ b/spec/root-apps/webpack2.spec.js
@@ -21,6 +21,7 @@ import returnsNonNativePromise from '../child-apps/returns-non-native-promise/re
 import invalidLoadFunction from '../child-apps/invalid-load-function/invalid-load-function.spec.js';
 import happyUnload from '../child-apps/happy-unload/happy-unload.spec.js';
 import invalidUnload from '../child-apps/invalid-unload/invalid-unload.spec.js';
+import lifecyleProps from '../child-apps/lifecycle-props/lifecycle-props.spec.js';
 
 describe('webpack2 loader', () => {
 	beforeAll(done => {
@@ -57,6 +58,7 @@ describe('webpack2 loader', () => {
 		invalidLoadFunction();
 		happyUnload();
 		invalidUnload();
+		lifecyleProps();
 	});
 });
 

--- a/src/child-applications/lifecycles/bootstrap.js
+++ b/src/child-applications/lifecycles/bootstrap.js
@@ -10,7 +10,7 @@ export async function toBootstrapPromise(app) {
 	app.status = BOOTSTRAPPING;
 
 	try {
-		await reasonableTime(app.bootstrap(), `Bootstrapping app '${app.name}'`, app.timeouts.bootstrap);
+		await reasonableTime(app.bootstrap({childAppName: app.name}), `Bootstrapping app '${app.name}'`, app.timeouts.bootstrap);
 		app.status = NOT_MOUNTED;
 	} catch(err) {
 		app.status = SKIP_BECAUSE_BROKEN;

--- a/src/child-applications/lifecycles/load.js
+++ b/src/child-applications/lifecycles/load.js
@@ -13,7 +13,7 @@ export async function toLoadPromise(app) {
 	let appOpts;
 
 	try {
-		const loadPromise = app.loadImpl();
+		const loadPromise = app.loadImpl({childAppName: app.name});
 		if (!smellsLikeAPromise(loadPromise)) {
 			// The name of the child app will be prepended to this error message inside of the handleChildAppError function
 			throw new Error(`single-spa loading function did not return a promise. Check the second argument to declareChildApplication('${app.name}', loadingFunction, activityFunction)`);
@@ -73,12 +73,12 @@ function flattenFnArray(fns, description) {
 		fns = [() => Promise.resolve()];
 	}
 
-	return function() {
+	return function(props) {
 		return new Promise((resolve, reject) => {
 			waitForPromises(0);
 
 			function waitForPromises(index) {
-				const promise = fns[index]();
+				const promise = fns[index](props);
 				if (!smellsLikeAPromise(promise)) {
 					reject(`${description} at index ${index} did not return a promise`);
 				} else {

--- a/src/child-applications/lifecycles/mount.js
+++ b/src/child-applications/lifecycles/mount.js
@@ -7,7 +7,7 @@ export async function toMountPromise(app) {
 		return app;
 	}
 	try {
-		await reasonableTime(app.mount(), `Mounting application '${app.name}'`, app.timeouts.mount);
+		await reasonableTime(app.mount({childAppName: app.name}), `Mounting application '${app.name}'`, app.timeouts.mount);
 		app.status = MOUNTED;
 	} catch (err) {
 		handleChildAppError(err, app);

--- a/src/child-applications/lifecycles/unload.js
+++ b/src/child-applications/lifecycles/unload.js
@@ -25,7 +25,7 @@ export async function toUnloadPromise(app) {
 
 	try {
 		app.status = UNLOADING;
-		await reasonableTime(app.unload(), `Unloading application '${app.name}'`, app.timeouts.unload);
+		await reasonableTime(app.unload({childAppName: app.name}), `Unloading application '${app.name}'`, app.timeouts.unload);
 	} catch (err) {
 		handleChildAppError(err, app);
 		app.status = SKIP_BECAUSE_BROKEN;

--- a/src/child-applications/lifecycles/unmount.js
+++ b/src/child-applications/lifecycles/unmount.js
@@ -9,7 +9,7 @@ export async function toUnmountPromise(app) {
 	app.status = UNMOUNTING;
 
 	try {
-		await reasonableTime(app.unmount(), `Unmounting application ${app.name}'`, app.timeouts.unmount);
+		await reasonableTime(app.unmount({childAppName: app.name}), `Unmounting application ${app.name}'`, app.timeouts.unmount);
 		app.status = NOT_MOUNTED;
 	} catch (err) {
 		handleChildAppError(err, app);


### PR DESCRIPTION
See #91. This will help with helper libraries (like single-spa-react or single-spa-canopy) that might not know which child app they're dealing with