### PR TITLE
Fixing bug in removeEventListener for hashchange/popstate listeners

### DIFF
--- a/spec/apis/event-listeners.spec.js
+++ b/spec/apis/event-listeners.spec.js
@@ -91,6 +91,7 @@ export function yesStartedEventListeners() {
 			}
 
 			function listener2() {
+				window.removeEventListener('hashchange', boundListener2); // cleanup after ourselves
 				done();
 			}
 		});

--- a/spec/apis/event-listeners.spec.js
+++ b/spec/apis/event-listeners.spec.js
@@ -66,6 +66,34 @@ export function yesStartedEventListeners() {
 				}
 			}
 		});
+
+		/* This regression tests a bug fix. The bug was that single-spa used to removeEventListener by checking if functions' toString() resulted in the
+		 * same string. In (at least) Chrome, this is problematic because you whenever you do fn.bind(null), the fn.toString() turns into
+		 * `function() { [native code] }`. So if you have multiple hashchange/popstate listeners that are bound functions, then when you call removeEventListener
+		 * on one of the bound functions, it will remove all of the bound functions so that they are no longer listening to the hashchange or popstate events.
+		 *
+		 * This test ensures that single-spa is checking triple equals equality instead of string equality when comparing functions to removeEventListener
+		 */
+		it(`window.removeEventListener only removes exactly one event listener, which must === the originally added listener. Even if the listener is a bound function`, done => {
+			const boundListener1 = listener1.bind(null);
+			const boundListener2 = listener2.bind(null);
+
+			window.addEventListener('hashchange', boundListener1);
+			window.addEventListener('hashchange', boundListener2);
+
+			window.removeEventListener('hashchange', boundListener1);
+
+			// This should trigger listener2 to be called
+			window.location.hash = `#/nowhere`;
+
+			function listener1() {
+				fail("listener1 should not be called, since it was removed");
+			}
+
+			function listener2() {
+				done();
+			}
+		});
 	});
 }
 

--- a/src/navigation/navigation-events.js
+++ b/src/navigation/navigation-events.js
@@ -81,7 +81,7 @@ window.addEventListener = function(eventName, fn) {
 window.removeEventListener = function(eventName, listenerFn) {
 	if (typeof listenerFn === 'function') {
 		if (routingEventsListeningTo.indexOf(eventName) >= 0) {
-			capturedEventListeners[eventName] = capturedEventListeners[eventName].filter(fn => fn.toString() !== listenerFn.toString());
+			capturedEventListeners[eventName] = capturedEventListeners[eventName].filter(fn => fn !== listenerFn);
 			return;
 		}
 	}


### PR DESCRIPTION
See notes in test for a description of what the bug was and how this fixes it. How this impacted the Canopy app is that if you ever went to a page where the contact-menu was active and then navigated away, then the primary-navbar's hashchange listener would never get called again. This resulted in the active tab in the primary navbar lagging behind what the hash actually said. So if you clicked on "Engagements" the menu item wouldn't go bold to indicate active until you forced a re-render of the primary-navbar app by navigating around or clicking.

For example, in the following screenshot, the Engagements menu item in the green navbar should be bold, but instead Contacts is bold.
![screen shot 2016-12-28 at 5 51 10 pm](https://cloud.githubusercontent.com/assets/5524384/21534559/4e591ed6-cd26-11e6-8524-38b48e2b23c8.png)
