### PR TITLE
Added a property to pass information from the root app to the child apps

### DIFF
--- a/spec/apps/lifecycle-props/lifecycle-props.spec.js
+++ b/spec/apps/lifecycle-props/lifecycle-props.spec.js
@@ -4,10 +4,6 @@ export default function() {
   describe(`lifecycle-props app`, () => {
     let myApp;
 
-    beforeAll(() => {
-      singleSpa.registerApplication('lifecycle-props', () => System.import('./lifecycle-props.app.js'), location => location.hash === activeHash);
-    });
-
     beforeEach(done => {
       System
       .import('./lifecycle-props.app.js')
@@ -21,6 +17,9 @@ export default function() {
     });
 
     it(`is given the correct props for each lifecycle function`, done => {
+
+      singleSpa.registerApplication('lifecycle-props', () => System.import('./lifecycle-props.app.js'), location => location.hash === activeHash);
+
       // This mounts the app
       window.location.hash = activeHash;
 
@@ -47,5 +46,36 @@ export default function() {
         done();
       });
     });
+
+    it(`is given the correct props for each lifecycle function if customProps are passed`, done => {
+
+      singleSpa.registerApplication('lifecycle-props-customProps', () => System.import('./lifecycle-props.app.js'), location => location.hash === activeHash, {test: 'test'});
+
+      // This mounts the app
+      window.location.hash = activeHash;
+
+      singleSpa
+        .triggerAppChange()
+        .then(() => {
+          // This unmounts the app
+          window.location.hash = `#/no-app`;
+          return singleSpa.triggerAppChange();
+        })
+        .then(() => {
+          return singleSpa.unloadApplication('lifecycle-props-customProps');
+        })
+        .then(() => {
+          expect(myApp.getBootstrapProps()).toEqual({appName: 'lifecycle-props-customProps', customProps: {test: 'test'}});
+          expect(myApp.getMountProps()).toEqual({appName: 'lifecycle-props-customProps', customProps: {test: 'test'}});
+          expect(myApp.getUnmountProps()).toEqual({appName: 'lifecycle-props-customProps', customProps: {test: 'test'}});
+          expect(myApp.getUnloadProps()).toEqual({appName: 'lifecycle-props-customProps', customProps: {test: 'test'}});
+
+          done();
+        })
+        .catch(err => {
+          fail(err);
+          done();
+        });
+      });
   });
 }

--- a/src/applications/app.helpers.js
+++ b/src/applications/app.helpers.js
@@ -57,3 +57,13 @@ export function notSkipped(item) {
 export function toName(app) {
   return app.name;
 }
+
+export function getAppProps(app) {
+    const props = {appName: app.name};
+
+    if (app.customProps) {
+        props.customProps = app.customProps;
+    }
+
+    return props;
+}

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -26,7 +26,7 @@ export function declareChildApplication(appName, arg1, arg2) {
   return registerApplication(appName, arg1, arg2)
 }
 
-export function registerApplication(appName, arg1, arg2) {
+export function registerApplication(appName, arg1, arg2, customProps) {
   if (typeof appName !== 'string' || appName.length === 0)
     throw new Error(`The first argument must be a non-empty string 'appName'`);
   if (apps[appName])
@@ -50,12 +50,18 @@ export function registerApplication(appName, arg1, arg2) {
   if (typeof activeWhen !== 'function')
     throw new Error(`The activeWhen argument must be a function`);
 
-  apps.push({
-    name: appName,
-    loadImpl,
-    activeWhen,
-    status: NOT_LOADED,
-  });
+  const app = {
+      name: appName,
+      loadImpl,
+      activeWhen,
+      status: NOT_LOADED,
+  };
+
+  if (customProps) {
+      app.customProps = customProps;
+  }
+
+  apps.push(app);
 
   ensureJQuerySupport();
 

--- a/src/applications/lifecycles/bootstrap.js
+++ b/src/applications/lifecycles/bootstrap.js
@@ -1,4 +1,4 @@
-import { NOT_BOOTSTRAPPED, BOOTSTRAPPING, NOT_MOUNTED, SKIP_BECAUSE_BROKEN } from '../app.helpers.js';
+import { NOT_BOOTSTRAPPED, BOOTSTRAPPING, NOT_MOUNTED, SKIP_BECAUSE_BROKEN, getAppProps } from '../app.helpers.js';
 import { reasonableTime } from '../timeouts.js';
 import { handleAppError } from '../app-errors.js';
 
@@ -10,7 +10,7 @@ export async function toBootstrapPromise(app) {
   app.status = BOOTSTRAPPING;
 
   try {
-    await reasonableTime(app.bootstrap({appName: app.name}), `Bootstrapping app '${app.name}'`, app.timeouts.bootstrap);
+    await reasonableTime(app.bootstrap(getAppProps(app)), `Bootstrapping app '${app.name}'`, app.timeouts.bootstrap);
     app.status = NOT_MOUNTED;
   } catch(err) {
     app.status = SKIP_BECAUSE_BROKEN;

--- a/src/applications/lifecycles/load.js
+++ b/src/applications/lifecycles/load.js
@@ -1,4 +1,4 @@
-import { NOT_BOOTSTRAPPED, LOADING_SOURCE_CODE, SKIP_BECAUSE_BROKEN, NOT_LOADED } from '../app.helpers.js';
+import { NOT_BOOTSTRAPPED, LOADING_SOURCE_CODE, SKIP_BECAUSE_BROKEN, NOT_LOADED, getAppProps } from '../app.helpers.js';
 import { ensureValidAppTimeouts } from '../timeouts.js';
 import { handleAppError } from '../app-errors.js';
 import { find } from 'src/utils/find.js';
@@ -13,7 +13,7 @@ export async function toLoadPromise(app) {
   let appOpts;
 
   try {
-    const loadPromise = app.loadImpl({appName: app.name});
+    const loadPromise = app.loadImpl(getAppProps(app));
     if (!smellsLikeAPromise(loadPromise)) {
       // The name of the app will be prepended to this error message inside of the handleAppError function
       throw new Error(`single-spa loading function did not return a promise. Check the second argument to registerApplication('${app.name}', loadingFunction, activityFunction)`);

--- a/src/applications/lifecycles/mount.js
+++ b/src/applications/lifecycles/mount.js
@@ -1,4 +1,4 @@
-import { NOT_MOUNTED, MOUNTED, SKIP_BECAUSE_BROKEN } from '../app.helpers.js';
+import { NOT_MOUNTED, MOUNTED, SKIP_BECAUSE_BROKEN, getAppProps } from '../app.helpers.js';
 import { handleAppError } from '../app-errors.js';
 import { reasonableTime } from '../timeouts.js';
 import CustomEvent from 'custom-event';
@@ -17,7 +17,7 @@ export async function toMountPromise(app) {
   }
 
   try {
-    await reasonableTime(app.mount({appName: app.name}), `Mounting application '${app.name}'`, app.timeouts.mount);
+    await reasonableTime(app.mount(getAppProps(app)), `Mounting application '${app.name}'`, app.timeouts.mount);
     app.status = MOUNTED;
   } catch (err) {
     handleAppError(err, app);

--- a/src/applications/lifecycles/unload.js
+++ b/src/applications/lifecycles/unload.js
@@ -1,4 +1,4 @@
-import { NOT_MOUNTED, UNLOADING, NOT_LOADED, SKIP_BECAUSE_BROKEN, isntActive } from '../app.helpers.js';
+import { NOT_MOUNTED, UNLOADING, NOT_LOADED, SKIP_BECAUSE_BROKEN, isntActive, getAppProps } from '../app.helpers.js';
 import { handleAppError } from '../app-errors.js';
 import { reasonableTime } from '../timeouts.js';
 
@@ -37,7 +37,7 @@ export async function toUnloadPromise(app) {
 
   try {
     app.status = UNLOADING;
-    await reasonableTime(app.unload({appName: app.name}), `Unloading application '${app.name}'`, app.timeouts.unload);
+    await reasonableTime(app.unload(getAppProps(app)), `Unloading application '${app.name}'`, app.timeouts.unload);
   } catch (err) {
     errorUnloadingApp(app, unloadInfo, err);
     return app;

--- a/src/applications/lifecycles/unmount.js
+++ b/src/applications/lifecycles/unmount.js
@@ -1,4 +1,4 @@
-import { UNMOUNTING, NOT_MOUNTED, MOUNTED, SKIP_BECAUSE_BROKEN } from '../app.helpers.js';
+import { UNMOUNTING, NOT_MOUNTED, MOUNTED, SKIP_BECAUSE_BROKEN, getAppProps } from '../app.helpers.js';
 import { handleAppError } from '../app-errors.js';
 import { reasonableTime } from '../timeouts.js';
 
@@ -9,7 +9,7 @@ export async function toUnmountPromise(app) {
   app.status = UNMOUNTING;
 
   try {
-    await reasonableTime(app.unmount({appName: app.name}), `Unmounting application ${app.name}'`, app.timeouts.unmount);
+    await reasonableTime(app.unmount(getAppProps(app)), `Unmounting application ${app.name}'`, app.timeouts.unmount);
     app.status = NOT_MOUNTED;
   } catch (err) {
     handleAppError(err, app);


### PR DESCRIPTION
I've added a third parameter to registerApplication which allows you to pass an object down to the child applications live cycle methods.

We needed something like this to enable cross application communication by injecting an instance of our event emitter down to the child app.

There was also a discussion about this here: https://github.com/CanopyTax/single-spa/issues/112

Here are a few examples on how to use it:

```
singleSpa.registerApplication('appName', () => true, () => true, 'test');
singleSpa.registerApplication('appName', () => true, () => true, {test: 'test'});
singleSpa.registerApplication('appName', () => true, () => true, {test: () => true});
singleSpa.registerApplication('appName', () => true, () => true, () => true);
```

And in your child app you will be able to access whatever you have passed from the root app:

```
// you can use all methods like bootstrap, mount, unmount, unload
export function bootstrap(props) {
	console.log(props.customProps);
        // output for the above examples:
        // test
        // {test: "test"}
        // {test: ƒ}
        // () => true
	return ngLifecycles.bootstrap(props);
}
```