### PR TITLE
Pass reference to singleSpa as a prop to lifecycle functions.

### DIFF
--- a/docs/applications.md
+++ b/docs/applications.md
@@ -32,7 +32,46 @@ Notes:
 
 ## Lifecyle props
 Lifecycle functions are called with a `props` argument, which is an object with some guaranteed information and also some custom information.
-`appName` string and a `customProps` object wich contains any property you want to pass from your root-application to your child app. See [Passing custom properties to child apps](/docs/applications.md#passing-custom-properties-to-child-apps)
+
+Example:
+```js
+function bootstrap(props) {
+  console.log(props) // will log appName, the singleSpa instance, and custom props
+  return Promise.resolve()
+}
+```
+
+#### Built-in props
+Each lifecycle function is guranteed to be called with the following props:
+- `appName`: The string name that was registered to single-spa.
+- `singleSpa`: A reference to the singleSpa instance, itself. This is intended to allow applications and helper libraries to call singleSpa
+  APIs without having to import it. This is useful in situations where there are multiple webpack configs that are not set up to ensure
+  that only one instance of singleSpa is loaded.
+
+#### Custom props
+In addition to the built-in props that are provided by single-spa, you may optionally specify custom props to be passed to an application.
+This is done by passing a fourth argument to registerApplication, which will be the customProps passed to each lifecycle method.
+
+Example:
+```js
+// root-application.js
+singleSpa.registerApplication('app1', () =>  {}, () => {}, {authToken: "d83jD63UdZ6RS6f70D0"});
+```
+
+```js
+// app1.js
+export function mount(props) {
+  console.log(props.customProps.authToken); // do something with the common authToken in app1
+  return reactLifecycles.mount(props);
+}
+```
+
+The usecases may include:
+- share common access Tokens with all child apps
+- pass down some initialization information like the rendering target
+- pass a reference to a common event bus so each app may talk to each other
+
+Note that when no customProps are provided during registration, `props.customProps` defaults to an empty object.
 
 ### Lifecycle helpers
 Helper libraries that helps implement lifecycle functions for specific frameworks, libraries, and applications
@@ -125,28 +164,6 @@ export function unload(props) {
 			// This is where you would normally do whatever it is you need to hot reload the code.
 			console.log('unloaded!');
 		});
-}
-```
-
-## Passing custom properties to child apps
-Each lifecycle method has a `props` property which contains an object with a `appName` string and a `customProps` object wich holds any information you want to pass to your child app.
-
-The usecases may include:
-- share common access Tokens with all child apps
-- pass down some initialization information like the rendering target
-- pass a reference to a common event bus so each app may talk to each other
-
-Here is a simple example on how to pass a authToken to a child app when the app is beeing mounted:
-```js
-// root-application.js
-singleSpa.registerApplication('app1', () =>  {}, () => {}, {authToken: "d83jD63UdZ6RS6f70D0"});
-```
-
-```js
-// app1.js
-export function mount(props) {
-  console.log(props.customProps.authToken); // do something with the common authToken in app1
-  return reactLifecycles.mount(props);
 }
 ```
 

--- a/docs/applications.md
+++ b/docs/applications.md
@@ -23,7 +23,6 @@ A lifecycle function is a function or array of functions that single-spa will ca
 Single-spa calls these by finding exported functions from the registered application's main file.
 
 Notes:
-- Lifecycle functions are called with a `props` argument, which is an object with a `appName` string and a `customProps` object wich contains any property you want to pass from your root-application to your child app. See [Passing custom properties to child apps](/docs/applications.md#passing-custom-properties-to-child-apps)
 - Implementing `bootstrap`, `mount`, and `unmount` is required. But implementing `unload` is optional.
 - Each lifecycle function must either return a `Promise` or be an `async function`.
 - If an array of functions is exported (instead of just one function), the functions will be called
@@ -31,8 +30,12 @@ Notes:
 - If single-spa is [not started](/docs/single-spa-api.md#start), applications will be loaded,
   but will not be bootstrapped, mounted or unmounted.
 
-### Lifecycle middleware
-Middleware that helps implement lifecycle functions for specific frameworks, libraries, and applications
+## Lifecyle props
+Lifecycle functions are called with a `props` argument, which is an object with some guaranteed information and also some custom information.
+`appName` string and a `customProps` object wich contains any property you want to pass from your root-application to your child app. See [Passing custom properties to child apps](/docs/applications.md#passing-custom-properties-to-child-apps)
+
+### Lifecycle helpers
+Helper libraries that helps implement lifecycle functions for specific frameworks, libraries, and applications
 is available for many popular technologies. See [the ecosystem docs](/docs/single-spa-ecosystem.md) for details.
 
 ### Load

--- a/spec/apps/lifecycle-props/lifecycle-props.spec.js
+++ b/spec/apps/lifecycle-props/lifecycle-props.spec.js
@@ -33,11 +33,18 @@ describe(`lifecycle-props app`, () => {
         return singleSpa.unloadApplication('lifecycle-props');
       })
       .then(() => {
-        expect(myApp.getBootstrapProps()).toEqual({appName: 'lifecycle-props', customProps: {}});
-        expect(myApp.getMountProps()).toEqual({appName: 'lifecycle-props', customProps: {}});
-        expect(myApp.getUnmountProps()).toEqual({appName: 'lifecycle-props', customProps: {}});
-        expect(myApp.getUnloadProps()).toEqual({appName: 'lifecycle-props', customProps: {}});
+        expectPropsToBeCorrect(myApp.getBootstrapProps())
+        expectPropsToBeCorrect(myApp.getMountProps())
+        expectPropsToBeCorrect(myApp.getUnmountProps())
+        expectPropsToBeCorrect(myApp.getUnloadProps())
       })
+
+    function expectPropsToBeCorrect(props) {
+      expect(props.appName).toEqual('lifecycle-props')
+      expect(props.customProps).toEqual({})
+      expect(props.singleSpa).toBeDefined()
+      expect(props.singleSpa.getAppStatus).toBeDefined()
+    }
   });
 
   it(`is given the correct props for each lifecycle function if customProps are passed`, () => {
@@ -56,10 +63,17 @@ describe(`lifecycle-props app`, () => {
       })
       .then(() => singleSpa.unloadApplication('lifecycle-props-customProps'))
       .then(() => {
-        expect(myApp.getBootstrapProps()).toEqual({appName: 'lifecycle-props-customProps', customProps: {test: 'test'}});
-        expect(myApp.getMountProps()).toEqual({appName: 'lifecycle-props-customProps', customProps: {test: 'test'}});
-        expect(myApp.getUnmountProps()).toEqual({appName: 'lifecycle-props-customProps', customProps: {test: 'test'}});
-        expect(myApp.getUnloadProps()).toEqual({appName: 'lifecycle-props-customProps', customProps: {test: 'test'}});
+        expectPropsToBeCorrect(myApp.getBootstrapProps())
+        expectPropsToBeCorrect(myApp.getMountProps())
+        expectPropsToBeCorrect(myApp.getUnmountProps())
+        expectPropsToBeCorrect(myApp.getUnloadProps())
+
+        function expectPropsToBeCorrect(props) {
+          expect(props.appName).toEqual('lifecycle-props-customProps')
+          expect(props.customProps).toEqual({test: 'test'})
+          expect(props.singleSpa).toBeDefined()
+          expect(props.singleSpa.getAppStatus).toBeDefined()
+        }
       })
     });
 });

--- a/src/applications/app.helpers.js
+++ b/src/applications/app.helpers.js
@@ -63,6 +63,6 @@ export function getAppProps(app) {
   return {
     appName: app.name,
     customProps: app.customProps,
-    singleSpa: singleSpa,
+    singleSpa,
   };
 }

--- a/src/applications/app.helpers.js
+++ b/src/applications/app.helpers.js
@@ -1,4 +1,5 @@
 import { handleAppError } from './app-errors.js';
+import * as singleSpa from 'src/single-spa.js';
 
 // App statuses
 export const NOT_LOADED = 'NOT_LOADED';
@@ -61,6 +62,7 @@ export function toName(app) {
 export function getAppProps(app) {
   return {
     appName: app.name,
-    customProps: app.customProps
+    customProps: app.customProps,
+    singleSpa: singleSpa,
   };
 }


### PR DESCRIPTION
See discussion in https://github.com/CanopyTax/single-spa/issues/180. This will allow helper libraries to call single-spa apis without worrying about whether the user of the helper library has ensured that only one instance of single-spa has been loaded.