### PR TITLE
Allowing mountParcel to be called with a loading function.

### DIFF
--- a/spec/parcels/mount-root-parcel.spec.js
+++ b/spec/parcels/mount-root-parcel.spec.js
@@ -44,6 +44,27 @@ describe(`root parcels`, () => {
         expect(unmountValue).toBe(null);
       })
   })
+
+  it(`lets you call mountParcel with a config loading function instead of an actual parcel config`, () => {
+    const parcelConfig = createParcelConfig();
+    let resolveConfigLoading
+    const configLoadingFunction = () => new Promise(resolve => {
+      resolveConfigLoading = () => resolve(parcelConfig)
+    })
+    const parcel = singleSpa.mountRootParcel(configLoadingFunction, {domElement: document.createElement('div')});
+    expect(parcel.getStatus()).toBe(singleSpa.LOADING_SOURCE_CODE);
+    return Promise
+      .resolve()
+      .then(() => expect(parcel.getStatus()).toBe(singleSpa.LOADING_SOURCE_CODE))
+      .then(() => resolveConfigLoading())
+      .then(() => parcel.loadPromise)
+      .then(() => expect(parcel.getStatus()).not.toBe(singleSpa.LOADING_SOURCE_CODE))
+      .then(() => parcel.mountPromise)
+      .then(() => expect(parcel.getStatus()).toBe(singleSpa.MOUNTED))
+      .then(() => parcel.unmount())
+      .then(() => expect(parcel.getStatus()).toBe(singleSpa.NOT_MOUNTED))
+      .then(() => parcel.unmountPromise)
+  })
 });
 
 function createParcelConfig() {

--- a/spec/parcels/parcel-error-handlers.spec.js
+++ b/spec/parcels/parcel-error-handlers.spec.js
@@ -139,7 +139,7 @@ describe('parcel errors', () => {
             }).then(() => {
               expect(errs.length).toBe(1);
               expect(errs[0].appName).toBe('app-parcel-unmount-errors');
-              expect(errs[0].message.indexOf(`Application 'app-parcel-unmount-errors' died in status UNMOUNTING: Parcel 'unmount-error' died in status UNMOUNTING: unmount error`)).toBeGreaterThan(-1);
+              expect(errs[0].message.indexOf(`Application 'app-parcel-unmount-errors' died in status UNMOUNTING: Parcel 'unmount-error' died in status SKIP_BECAUSE_BROKEN: Parcel 'unmount-error' died in status UNMOUNTING: unmount error`)).toBeGreaterThan(-1);
             })
           })
         })

--- a/spec/parcels/parcel-error-handlers.spec.js
+++ b/spec/parcels/parcel-error-handlers.spec.js
@@ -146,6 +146,69 @@ describe('parcel errors', () => {
       })
     })
   })
+
+  describe(`invalid config`, () => {
+    it(`throws an error immediately if you don't provide a config object`, () => {
+      expect(() => {
+        singleSpa.mountRootParcel(null, {domElement: document.createElement('div')})
+      }).toThrow()
+    })
+
+    it(`throws if your loading function doesn't return a valid config promise`, () => {
+      expect(() => {
+        // loading function should return promise
+        singleSpa.mountRootParcel(() => createParcelConfig(), {domElement: document.createElement('div')})
+      }).toThrow()
+    })
+
+    it(`rejects the load promise if loading function returns a promise that resolves with undefined`, () => {
+      const parcel = singleSpa.mountRootParcel(() => Promise.resolve(), {domElement: document.createElement('div')})
+      return parcel.loadPromise.then(
+        () => {
+          throw new Error('load promise should not have succeeded')
+        },
+        err => {
+          expect(err.message.indexOf('did not resolve with a parcel config')).toBeGreaterThan(-1)
+        }
+      )
+    })
+
+    it(`rejects the load promise if the config doesn't have a valid bootstrap function`, () => {
+      const parcel = singleSpa.mountRootParcel({mount() {}, unmount() {}}, {domElement: document.createElement('div')})
+      return parcel.loadPromise.then(
+        () => {
+          throw new Error('load promise should not have succeeded')
+        },
+        err => {
+          expect(err.message.indexOf('must have a valid bootstrap function')).toBeGreaterThan(-1)
+        }
+      )
+    })
+
+    it(`rejects the load promise if the config doesn't have a valid mount function`, () => {
+      const parcel = singleSpa.mountRootParcel({bootstrap() {}, unmount() {}}, {domElement: document.createElement('div')})
+      return parcel.loadPromise.then(
+        () => {
+          throw new Error('load promise should not have succeeded')
+        },
+        err => {
+          expect(err.message.indexOf('must have a valid mount function')).toBeGreaterThan(-1)
+        }
+      )
+    })
+
+    it(`rejects the load promise if the config doesn't have a valid unmount function`, () => {
+      const parcel = singleSpa.mountRootParcel({bootstrap() {}, mount() {}}, {domElement: document.createElement('div')})
+      return parcel.loadPromise.then(
+        () => {
+          throw new Error('load promise should not have succeeded')
+        },
+        err => {
+          expect(err.message.indexOf('must have a valid unmount function')).toBeGreaterThan(-1)
+        }
+      )
+    })
+  })
 })
 
 function createApp() {


### PR DESCRIPTION
The purpose of allowing mountParcel to be called with a loading function (that returns a Promise that resolves with the config) is to encourage lazy loading of code. Similar to what we do with loading functions for applications.

This allows for some really cool code splitting things, especially in conjunction with the `<Parcel>` component I'm building for single-spa-react.

```jsx
// vanilla javascript example
const parcel = mountParcel(() => import('./parcel.js').then(parcelModule => parcelModule.default), {domElement: ...})
parcel.loadPromise.then(() => {
  console.log('finished lazy loading parcel. Now it will be mounted!')
})

// react example for Canopy code
<Parcel
 config={() => SystemJS.import('calendar-ui!sofe').then(calendarUI => calendarUI.createEventParcel)}
 clientId={1}
/>

// react example for non canopy code
<Parcel
 config={() => import('./calendar-ui.js').then(calendarUI => calendarUI.createEventParcel)}
 clientId={1}
/>
```