### PR TITLE
Added module package entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.1",
   "description": "Multiple applications, one page",
   "main": "lib/single-spa.js",
+  "module: "src/single-spa.js",
   "scripts": {
     "build": "webpack -p",
     "build:dev": "webpack --config webpack.config.dev.js",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.1",
   "description": "Multiple applications, one page",
   "main": "lib/single-spa.js",
-  "module: "src/single-spa.js",
+  "module": "src/single-spa.js",
   "scripts": {
     "build": "webpack -p",
     "build:dev": "webpack --config webpack.config.dev.js",


### PR DESCRIPTION
This helps bundlers like rollup to resolve the module name, instead of using the compiled lib version, that forces using the rollup-plugin-commonjs