### PR TITLE
Add module entry on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "4.0.1",
   "description": "Multiple applications, one page",
   "main": "lib/single-spa.js",
+  "module": "src/single-spa.js",
   "scripts": {
     "build": "webpack -p",
     "build:dev": "webpack --config webpack.config.dev.js",


### PR DESCRIPTION
This entry helps out with rollup bundling. Since the transpiled library located at "lib/single-spa.js" is in CommonJS format, rollup (more precisely rollup-plugin-commonjs plugin) has trouble finding the exports, unless they are named on the namedExports configuration.

If instead we set a module name on the package.json, this change solves this specific issue.