### PR TITLE
Adding support for devtools to manage force mounting/unmounting

### DIFF
--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -59,6 +59,7 @@ export function registerApplication(appName, applicationOrLoadingFn, activityFn,
     activeWhen: activityFn,
     status: NOT_LOADED,
     parcels: {},
+    devtools: {},
     customProps
   });
 

--- a/src/devtools/devtools.js
+++ b/src/devtools/devtools.js
@@ -1,5 +1,8 @@
 import {getRawAppData} from '../applications/apps'
-import { reroute } from '../navigation/reroute';
+import {reroute} from '../navigation/reroute'
+import {NOT_LOADED} from '../applications/app.helpers'
+import {toLoadPromise} from '../lifecycles/load'
+import {toBootstrapPromise} from '../lifecycles/bootstrap'
 
 export const getAppData = getRawAppData
 export const forceMount = forceMountUnmount.bind(null, true)
@@ -7,24 +10,35 @@ export const forceUnmount = forceMountUnmount.bind(null, false)
 
 export function revertForceMountUnmount(appName) {
   const app = getRawAppData().find(rawapp => rawapp.name === appName)
-  if(app[activeWhenBackup]) {
-    app.activeWhen = app[activeWhenBackup]
-    delete app[activeWhenBackup]
-    delete app.__activeWhenOverride__
+  if(app.devtools.activeWhenBackup) {
+    app.activeWhen = app.devtools.activeWhenBackup
+    delete app.devtools.activeWhenBackup
+    delete app.devtools.activeWhenForced
   }
   reroute()
 }
 
-// as much as possible, we try to avoid putting anything on the app object that could potenetially confict. Symbols to the resuce!
-const activeWhenBackup = Symbol("activeWhenBackup")
 function forceMountUnmount(shouldMount, appName) {
   const app = getRawAppData().find(rawapp => rawapp.name === appName)
-  if(!app[activeWhenBackup]) {
+
+  if(!app.devtools.activeWhenBackup) {
     // only set the backup when there isn't one already. otherwise you could potentilaly overwrite it with "always on" or "always off"
-    app[activeWhenBackup] = app.activeWhen
+    app.devtools.activeWhenBackup = app.activeWhen
   }
-  // don't use a symbol for __activeWhenOverride__ because it needs to be read in the context of devtools, which means it's JSON.string-ified and Symbols don't survive that
-  app.__activeWhenOverride__ = shouldMount ? "on" : "off"
+
+  app.devtools.activeWhenForced = shouldMount ? "on" : "off"
   app.activeWhen = () => shouldMount
-  reroute()
+
+  if(shouldMount && app.status === NOT_LOADED) {
+    // we can't mount a NOT_LOADED app, so let's load and bootstrap it first
+    toLoadPromise(app)
+    .then(() => toBootstrapPromise(app))
+    .then(() => reroute())
+    .catch(err => {
+      console.error(`Something failed in the process of loading and bootstrapping your force mounted app (${app.name}):`, err)
+      throw err
+    })
+  } else {
+    reroute()
+  }
 }

--- a/src/devtools/devtools.js
+++ b/src/devtools/devtools.js
@@ -1,5 +1,30 @@
 import {getRawAppData} from '../applications/apps'
+import { reroute } from '../navigation/reroute';
 
-export function getAppData() {
-  return getRawAppData()
+export const getAppData = getRawAppData
+export const forceMount = forceMountUnmount.bind(null, true)
+export const forceUnmount = forceMountUnmount.bind(null, false)
+
+export function revertForceMountUnmount(appName) {
+  const app = getRawAppData().find(rawapp => rawapp.name === appName)
+  if(app[activeWhenBackup]) {
+    app.activeWhen = app[activeWhenBackup]
+    delete app[activeWhenBackup]
+    delete app.__activeWhenOverride__
+  }
+  reroute()
+}
+
+// as much as possible, we try to avoid putting anything on the app object that could potenetially confict. Symbols to the resuce!
+const activeWhenBackup = Symbol("activeWhenBackup")
+function forceMountUnmount(shouldMount, appName) {
+  const app = getRawAppData().find(rawapp => rawapp.name === appName)
+  if(!app[activeWhenBackup]) {
+    // only set the backup when there isn't one already. otherwise you could potentilaly overwrite it with "always on" or "always off"
+    app[activeWhenBackup] = app.activeWhen
+  }
+  // don't use a symbol for __activeWhenOverride__ because it needs to be read in the context of devtools, which means it's JSON.string-ified and Symbols don't survive that
+  app.__activeWhenOverride__ = shouldMount ? "on" : "off"
+  app.activeWhen = () => shouldMount
+  reroute()
 }


### PR DESCRIPTION
In the example below, contact-menu was force mounted so it has the option to force unmount and reset to default.

contacts-ui was force unmounted so it can be force mounted and reset to default.

The others in red are not mounted, so they can be force mounted if you want.

primary-navbar is mounted naturally, so you can force unmount if you want.

<img width="587" alt="screen shot 2019-02-02 at 4 40 51 pm" src="https://user-images.githubusercontent.com/3054066/52170632-19a6dc00-270b-11e9-856b-7afe37ed9970.png">