### PR TITLE
changing to .min.js and small additions to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "single-spa",
   "version": "4.1.1",
   "description": "Multiple applications, one page",
-  "main": "lib/umd/single-spa.js",
-  "module:": "lib/esm/single-spa.js",
+  "main": "lib/umd/single-spa.min.js",
+  "module:": "lib/esm/single-spa.min.js",
   "scripts": {
     "build": "rollup -c --environment NODE_ENV:'production'",
     "build:dev": "rollup -c",
@@ -15,7 +15,9 @@
     "test:debug": "BABEL_ENV=test jest --watch",
     "lint": "eslint src"
   },
+  "homepage": "https://single-spa.js.org",
   "repository": "https://github.com/CanopyTax/single-spa",
+  "bugs": "https://github.com/CanopyTax/single-spa/issues",
   "keywords": [
     "single",
     "page",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ export default (async () => ([
   {
     input: './src/single-spa.js',
     output: {
-      file: './lib/umd/single-spa.js',
+      file: './lib/umd/single-spa.min.js',
       format: 'umd',
       name: 'singleSpa',
       sourcemap: true,
@@ -28,7 +28,7 @@ export default (async () => ([
   {
     input: './src/single-spa.js',
     output: {
-      file: './lib/esm/single-spa.js',
+      file: './lib/esm/single-spa.min.js',
       format: 'esm',
       sourcemap: true,
     },


### PR DESCRIPTION
since our files are minified, we should indicate that with the common pattern.

also, cdnjs will run a minifier on your code if you don't have that filename pattern. But since we're already minified, let's not make cdnjs do that extra work