### PR TITLE
Also bundling to System.register format, for script tagging.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/umd/single-spa.min.js",
   "module:": "lib/esm/single-spa.min.js",
   "scripts": {
-    "build": "rollup -c --environment NODE_ENV:'production'",
+    "build": "yarn clean && rollup -c --environment NODE_ENV:'production'",
     "build:dev": "rollup -c",
     "build:analyze": "rollup -c --environment ANALYZER:'analyzer'",
     "watch": "rollup -c -w",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,5 +41,22 @@ export default (async () => ([
       isProduction && (await import('rollup-plugin-terser')).terser(),
       useAnalyzer && analyzer()
     ]
-  }
+  },
+  {
+    input: './src/single-spa.js',
+    output: {
+      file: './lib/system/single-spa.min.js',
+      format: 'system',
+      sourcemap: true,
+    },
+    plugins: [
+      resolve(),
+      commonjs(),
+      babel({
+        exclude: 'node_modules/**'
+      }),
+      isProduction && (await import('rollup-plugin-terser')).terser(),
+      useAnalyzer && analyzer()
+    ]
+  },
 ]))()


### PR DESCRIPTION
This will make it possible for us to use single-spa and systemjs together without having to use the AMD extra in SystemJS