### PR TITLE
Only publish lib, typings folders to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
       "pre-push": "yarn test && yarn lint"
     }
   },
+  "files": [
+    "lib",
+    "typings"
+  ],
   "homepage": "https://single-spa.js.org",
   "repository": "https://github.com/CanopyTax/single-spa",
   "bugs": "https://github.com/CanopyTax/single-spa/issues",


### PR DESCRIPTION
Fixes https://github.com/CanopyTax/single-spa/issues/316

You can run `npm pack --dry-run` to verify the files included in the published package. Here's the output below. 

```
$ npm pack --dry-run
npm WARN prepublish-on-install As of npm@5, `prepublish` scripts are deprecated.
npm WARN prepublish-on-install Use `prepare` for build steps and `prepublishOnly` for upload-only.
npm WARN prepublish-on-install See the deprecation note in `npm help scripts` for more information.

> single-spa@4.3.4 prepublish /Users/pmikitsh/git/single-spa
> in-publish && yarn build || not-in-publish

npm notice 
npm notice 📦  single-spa@4.3.4
npm notice === Tarball Contents === 
npm notice 2.1kB  package.json                    
npm notice 118B   CHANGELOG.md                    
npm notice 1.1kB  LICENSE                         
npm notice 3.1kB  README.md                       
npm notice 21.0kB lib/esm/single-spa.min.js       
npm notice 70.0kB lib/esm/single-spa.min.js.map   
npm notice 21.1kB lib/system/single-spa.min.js    
npm notice 70.0kB lib/system/single-spa.min.js.map
npm notice 21.2kB lib/umd/single-spa.min.js       
npm notice 70.0kB lib/umd/single-spa.min.js.map   
npm notice 2.6kB  typings/single-spa.d.ts         
npm notice === Tarball Details === 
npm notice name:          single-spa                              
npm notice version:       4.3.4                                   
npm notice filename:      single-spa-4.3.4.tgz                    
npm notice package size:  79.8 kB                                 
npm notice unpacked size: 282.3 kB                                
npm notice shasum:        14e19495b00ba432dac7ee653e83342c43236998
npm notice integrity:     sha512-Ne2n7ENbqfXNK[...]MEkuC7W8yfNXQ==
npm notice total files:   11                                      
npm notice 
single-spa-4.3.4.tgz
```

Here's a summary package size of current master:

```
npm notice === Tarball Details === 
npm notice name:          single-spa                              
npm notice version:       4.3.4                                   
npm notice filename:      single-spa-4.3.4.tgz                    
npm notice package size:  176.2 kB                                
npm notice unpacked size: 552.4 kB   
```

Less than half the original size.