### PR TITLE
(5.0) Improving perf with babel/rollup changes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,26 @@
 {
-  "presets": [["@babel/preset-env", { "modules": false }]],
-  "plugins": ["@babel/plugin-syntax-dynamic-import"],
+  "presets": [
+    ["@babel/preset-env", {
+      "modules": false
+    }]
+  ],
   "env": {
     "test": {
       "presets": ["@babel/preset-env"],
-      "plugins": ["dynamic-import-node"]
+      "plugins": ["dynamic-import-node", "@babel/plugin-syntax-dynamic-import"]
+    },
+    "esm": {
+      "presets": [
+        [
+          "@babel/preset-env",
+          {
+            "modules": false,
+            "targets": {
+              "esmodules": true
+            }
+          }
+        ]
+      ]
     }
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8.11.1"
+  - "node"
 script:
   - yarn build
   - yarn lint

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@babel/preset-env": "^7.5.5",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^24.9.0",
-    "babel-loader": "^8.0.4",
     "babel-plugin-dynamic-import-node": "^2.3.0",
     "concurrently": "^5.0.0",
     "custom-event": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "typings/single-spa.d.ts",
   "module": "lib/esm/single-spa.min.js",
   "scripts": {
-    "build": "yarn clean && npm run build:prod && npm run build:dev",
+    "build": "yarn clean && concurrently yarn:build:dev yarn:build:prod",
     "build:prod": "rollup -c --environment NODE_ENV:'production'",
     "build:dev": "rollup -c",
     "build:analyze": "rollup -c --environment ANALYZER:'analyzer'",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,6 +6,17 @@ import analyzer from "rollup-plugin-analyzer";
 const isProduction = process.env.NODE_ENV === "production";
 const useAnalyzer = process.env.ANALYZER === "analyzer";
 
+const babelOpts = {
+  exclude: "node_modules/**"
+};
+
+const terserOpts = {
+  compress: {
+    passes: 2
+  },
+  module: true
+};
+
 export default (async () => [
   {
     input: "./src/single-spa.js",
@@ -18,10 +29,8 @@ export default (async () => [
     plugins: [
       resolve(),
       commonjs(),
-      babel({
-        exclude: "node_modules/**"
-      }),
-      isProduction && (await import("rollup-plugin-terser")).terser(),
+      babel(babelOpts),
+      isProduction && (await import("rollup-plugin-terser")).terser(terserOpts),
       useAnalyzer && analyzer()
     ]
   },
@@ -35,10 +44,17 @@ export default (async () => [
     plugins: [
       resolve(),
       commonjs(),
-      babel({
-        exclude: "node_modules/**"
-      }),
-      isProduction && (await import("rollup-plugin-terser")).terser(),
+      babel(
+        Object.assign({}, babelOpts, {
+          envName: "esm"
+        })
+      ),
+      isProduction &&
+        (await import("rollup-plugin-terser")).terser(
+          Object.assign({}, terserOpts, {
+            ecma: 6
+          })
+        ),
       useAnalyzer && analyzer()
     ]
   },
@@ -52,10 +68,8 @@ export default (async () => [
     plugins: [
       resolve(),
       commonjs(),
-      babel({
-        exclude: "node_modules/**"
-      }),
-      isProduction && (await import("rollup-plugin-terser")).terser(),
+      babel(babelOpts),
+      isProduction && (await import("rollup-plugin-terser")).terser(terserOpts),
       useAnalyzer && analyzer()
     ]
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1229,16 +1229,6 @@ babel-jest@^24.9.0:
     chalk "^2.4.2"
     slash "^2.0.0"
 
-babel-loader@^8.0.4:
-  version "8.0.6"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.0.6.tgz#e33bdb6f362b03f4bb141a0c21ab87c501b70dfb"
-  integrity sha512-4BmWKtBOBm13uoUwd08UwjZlaw3O9GWf456R9j+5YykFZ6LUIjIKLc0zEZf+hauxPOJs96C8k6FvYD09vWzhYw==
-  dependencies:
-    find-cache-dir "^2.0.0"
-    loader-utils "^1.0.2"
-    mkdirp "^0.5.1"
-    pify "^4.0.1"
-
 babel-plugin-dynamic-import-node@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.0.tgz#f00f507bdaa3c3e3ff6e7e5e98d90a7acab96f7f"
@@ -1294,11 +1284,6 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
-
-big.js@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
-  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1533,11 +1518,6 @@ commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
-
-commondir@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
-  integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -1795,11 +1775,6 @@ emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
   integrity sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
-
-emojis-list@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
-  integrity sha1-TapNnbAPmBmIDHn6RXrlsJof04k=
 
 end-of-stream@^1.1.0:
   version "1.4.4"
@@ -2142,15 +2117,6 @@ fill-range@^4.0.0:
     is-number "^3.0.0"
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
-
-find-cache-dir@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
-  integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
-  dependencies:
-    commondir "^1.0.1"
-    make-dir "^2.0.0"
-    pkg-dir "^3.0.0"
 
 find-up@^3.0.0:
   version "3.0.0"
@@ -3268,13 +3234,6 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
-  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
-  dependencies:
-    minimist "^1.2.0"
-
 json5@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6"
@@ -3361,15 +3320,6 @@ load-json-file@^4.0.0:
     pify "^3.0.0"
     strip-bom "^3.0.0"
 
-loader-utils@^1.0.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
-  integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
-  dependencies:
-    big.js "^5.2.2"
-    emojis-list "^2.0.0"
-    json5 "^1.0.1"
-
 locate-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
@@ -3409,7 +3359,7 @@ magic-string@^0.25.2:
   dependencies:
     sourcemap-codec "^1.4.4"
 
-make-dir@^2.0.0, make-dir@^2.1.0:
+make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
   integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==


### PR DESCRIPTION
Before:

```js
23778 bytes - lib/esm/single-spa.min.js
23800 bytes - lib/system/single-spa.min.js
23997 bytes - lib/umd/single-spa.min.js
```

After:
```js
20571 bytes - lib/esm/single-spa.min.js
23788 bytes - lib/system/single-spa.min.js
23985 bytes - lib/umd/single-spa.min.js
```

The main changes here are that we are targeting different browsers now for the `esm` build of single-spa. Since IE11 and older versions of Edge/Safari do not support ES modules syntax, we don't need the esm bundle to support those browsers. Babel has an [`esmodules`](https://babeljs.io/docs/en/babel-preset-env#targetsesmodules) option for selecting browsers that support es modules. And terser has an [`ecma option`](https://github.com/terser/terser#minify-options) which I've changed to `6` for the ESM build.