### PR TITLE
(5.0): Reducing bundle size by removing class syntax

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "8.11.1"
+  - "node"
 script:
   - yarn build
   - yarn lint


### PR DESCRIPTION
Before:
```sh
23778 bytes - lib/esm/single-spa.min.js
23800 bytes - lib/system/single-spa.min.js
23997 bytes - lib/umd/single-spa.min.js
```

After:
```sh
21979 bytes - lib/esm/single-spa.min.js
22003 bytes - lib/system/single-spa.min.js
22200 bytes - lib/umd/single-spa.min.js
```

The reason is that the `class` syntax is not supported in IE11 and other older browsers. The babel polyfill for classes is pretty big.