### PR TITLE
Switching from object rest spread to manual assign.

### DIFF
--- a/src/applications/timeouts.js
+++ b/src/applications/timeouts.js
@@ -120,6 +120,6 @@ export function reasonableTime(promise, description, timeoutConfig) {
   });
 }
 
-export function ensureValidAppTimeouts(timeouts = {}) {
-  return assign({}, globalTimeoutConfig, timeouts);
+export function ensureValidAppTimeouts(timeouts) {
+  return assign({}, globalTimeoutConfig, timeouts || {});
 }

--- a/src/applications/timeouts.js
+++ b/src/applications/timeouts.js
@@ -166,9 +166,8 @@ export function ensureValidAppTimeouts(timeouts) {
   const result = {};
 
   for (let key in globalTimeoutConfig) {
-    result[key] = {};
-    assign(
-      result[key],
+    result[key] = assign(
+      {},
       globalTimeoutConfig[key],
       (timeouts && timeouts[key]) || {}
     );

--- a/src/applications/timeouts.js
+++ b/src/applications/timeouts.js
@@ -1,3 +1,5 @@
+import { assign } from "../utils/assign";
+
 const globalTimeoutConfig = {
   bootstrap: {
     millis: 4000,
@@ -119,8 +121,5 @@ export function reasonableTime(promise, description, timeoutConfig) {
 }
 
 export function ensureValidAppTimeouts(timeouts = {}) {
-  return {
-    ...globalTimeoutConfig,
-    ...timeouts
-  };
+  return assign({}, globalTimeoutConfig, timeouts);
 }

--- a/src/lifecycles/load.js
+++ b/src/lifecycles/load.js
@@ -13,6 +13,7 @@ import {
   validLifecycleFn
 } from "./lifecycle.helpers.js";
 import { getProps } from "./prop.helpers.js";
+import { assign } from "../utils/assign.js";
 
 export function toLoadPromise(app) {
   return Promise.resolve().then(() => {
@@ -68,10 +69,11 @@ export function toLoadPromise(app) {
           }
 
           if (appOpts.devtools && appOpts.devtools.overlays) {
-            app.devtools.overlays = {
-              ...app.devtools.overlays,
-              ...appOpts.devtools.overlays
-            };
+            app.devtools.overlays = assign(
+              {},
+              app.devtools.overlays,
+              appOpts.devtools.overlays
+            );
           }
 
           app.status = NOT_BOOTSTRAPPED;

--- a/src/lifecycles/prop.helpers.js
+++ b/src/lifecycles/prop.helpers.js
@@ -1,13 +1,13 @@
 import * as singleSpa from "../single-spa.js";
 import { mountParcel } from "../parcels/mount-parcel.js";
+import { assign } from "../utils/assign.js";
 
 export function getProps(appOrParcel) {
-  const result = {
-    ...appOrParcel.customProps,
+  const result = assign({}, appOrParcel.customProps, {
     name: appOrParcel.name,
     mountParcel: mountParcel.bind(appOrParcel),
     singleSpa
-  };
+  });
 
   if (appOrParcel.unmountThisParcel) {
     result.unmountSelf = appOrParcel.unmountThisParcel;

--- a/src/lifecycles/prop.helpers.js
+++ b/src/lifecycles/prop.helpers.js
@@ -1,11 +1,11 @@
 import * as singleSpa from "../single-spa.js";
 import { mountParcel } from "../parcels/mount-parcel.js";
 import { assign } from "../utils/assign.js";
-import { isParcel } from "../applications/app.helpers.js";
+import { isParcel, toName } from "../applications/app.helpers.js";
 
 export function getProps(appOrParcel) {
   const result = assign({}, appOrParcel.customProps, {
-    name: appOrParcel.name,
+    name: toName(appOrParcel),
     mountParcel: mountParcel.bind(appOrParcel),
     singleSpa
   });

--- a/src/utils/assign.js
+++ b/src/utils/assign.js
@@ -1,0 +1,11 @@
+// Object.assign() is not available in IE11. And the babel compiled output for object spread
+// syntax checks a bunch of Symbol stuff and is almost a kb. So this function is the smaller replacement.
+export function assign() {
+  for (let i = arguments.length - 1; i > 0; i--) {
+    for (let key in arguments[i]) {
+      arguments[i - 1][key] = arguments[i][key];
+    }
+  }
+
+  return arguments[0];
+}

--- a/src/utils/assign.js
+++ b/src/utils/assign.js
@@ -3,6 +3,9 @@
 export function assign() {
   for (let i = arguments.length - 1; i > 0; i--) {
     for (let key in arguments[i]) {
+      if (key === "__proto__") {
+        continue;
+      }
       arguments[i - 1][key] = arguments[i][key];
     }
   }


### PR DESCRIPTION
esm/single-spa.min.js decreases from 19161 to 18533 bytes with this change. The reason is that object spread gets compiled down in a pretty funky way (presumably for spec compliance) where it checks all sorts of Symbol related things that aren't even available in IE11.