### PR TITLE
Updating link to error codes

### DIFF
--- a/spec/apis/timeout-apis.spec.js
+++ b/spec/apis/timeout-apis.spec.js
@@ -43,7 +43,7 @@ describe("global timeout configuration", () => {
         10
       );
       expectError(
-        `single-spa minified message #31: Lifecycle function bootstrap for parcel bootstrap-1 lifecycle did not resolve or reject for 5 ms. See https://single-spa.js.org/error?code=31&arg=bootstrap&arg=parcel&arg=bootstrap-1&arg=5`
+        `single-spa minified message #31: Lifecycle function bootstrap for parcel bootstrap-1 lifecycle did not resolve or reject for 5 ms. See https://single-spa.js.org/error/?code=31&arg=bootstrap&arg=parcel&arg=bootstrap-1&arg=5`
       );
     });
 
@@ -63,7 +63,7 @@ describe("global timeout configuration", () => {
         10
       );
       expectWarning(
-        `single-spa minified message #31: Lifecycle function bootstrap for parcel bootstrap-3 lifecycle did not resolve or reject for 15 ms. See https://single-spa.js.org/error?code=31&arg=bootstrap&arg=parcel&arg=bootstrap-3&arg=15`
+        `single-spa minified message #31: Lifecycle function bootstrap for parcel bootstrap-3 lifecycle did not resolve or reject for 15 ms. See https://single-spa.js.org/error/?code=31&arg=bootstrap&arg=parcel&arg=bootstrap-3&arg=15`
       );
     });
   });
@@ -91,7 +91,7 @@ describe("global timeout configuration", () => {
         10
       );
       expectError(
-        `single-spa minified message #31: Lifecycle function mount for parcel mount-1 lifecycle did not resolve or reject for 5 ms. See https://single-spa.js.org/error?code=31&arg=mount&arg=parcel&arg=mount-1&arg=5`
+        `single-spa minified message #31: Lifecycle function mount for parcel mount-1 lifecycle did not resolve or reject for 5 ms. See https://single-spa.js.org/error/?code=31&arg=mount&arg=parcel&arg=mount-1&arg=5`
       );
     });
 
@@ -113,7 +113,7 @@ describe("global timeout configuration", () => {
         10
       );
       expectWarning(
-        `single-spa minified message #31: Lifecycle function mount for parcel mount-3 lifecycle did not resolve or reject for 15 ms. See https://single-spa.js.org/error?code=31&arg=mount&arg=parcel&arg=mount-3&arg=15`
+        `single-spa minified message #31: Lifecycle function mount for parcel mount-3 lifecycle did not resolve or reject for 15 ms. See https://single-spa.js.org/error/?code=31&arg=mount&arg=parcel&arg=mount-3&arg=15`
       );
     });
   });
@@ -136,7 +136,7 @@ describe("global timeout configuration", () => {
 
       await controlledParcelActions(unmount, "unmount-1", 0, 0, 0, 10);
       expectError(
-        `single-spa minified message #31: Lifecycle function unmount for parcel unmount-1 lifecycle did not resolve or reject for 5 ms. See https://single-spa.js.org/error?code=31&arg=unmount&arg=parcel&arg=unmount-1&arg=5`
+        `single-spa minified message #31: Lifecycle function unmount for parcel unmount-1 lifecycle did not resolve or reject for 5 ms. See https://single-spa.js.org/error/?code=31&arg=unmount&arg=parcel&arg=unmount-1&arg=5`
       );
     });
 
@@ -148,7 +148,7 @@ describe("global timeout configuration", () => {
 
       await controlledParcelActions(unmount, "unmount-3", 0, 0, 0, 10);
       expectWarning(
-        `single-spa minified message #31: Lifecycle function unmount for parcel unmount-3 lifecycle did not resolve or reject for 15 ms. See https://single-spa.js.org/error?code=31&arg=unmount&arg=parcel&arg=unmount-3&arg=15`
+        `single-spa minified message #31: Lifecycle function unmount for parcel unmount-3 lifecycle did not resolve or reject for 15 ms. See https://single-spa.js.org/error/?code=31&arg=unmount&arg=parcel&arg=unmount-3&arg=15`
       );
     });
   });

--- a/spec/apps/warning-timeouts/warning-timeouts.spec.js
+++ b/spec/apps/warning-timeouts/warning-timeouts.spec.js
@@ -65,10 +65,10 @@ describe(`warning-timeouts app`, () => {
     expect(singleSpa.getAppStatus("warning-timeouts")).toEqual("MOUNTED");
     expect(errs.length).toBe(0);
     expectWarning(
-      `single-spa minified message #31: Lifecycle function bootstrap for application warning-timeouts lifecycle did not resolve or reject for 4000 ms. See https://single-spa.js.org/error?code=31&arg=bootstrap&arg=application&arg=warning-timeouts&arg=4000`
+      `single-spa minified message #31: Lifecycle function bootstrap for application warning-timeouts lifecycle did not resolve or reject for 4000 ms. See https://single-spa.js.org/error/?code=31&arg=bootstrap&arg=application&arg=warning-timeouts&arg=4000`
     );
     expectWarning(
-      `single-spa minified message #31: Lifecycle function mount for application warning-timeouts lifecycle did not resolve or reject for 3000 ms. See https://single-spa.js.org/error?code=31&arg=mount&arg=application&arg=warning-timeouts&arg=3000`
+      `single-spa minified message #31: Lifecycle function mount for application warning-timeouts lifecycle did not resolve or reject for 3000 ms. See https://single-spa.js.org/error/?code=31&arg=mount&arg=application&arg=warning-timeouts&arg=3000`
     );
 
     location.hash = "#not-warning-timeouts";

--- a/src/applications/app-errors.js
+++ b/src/applications/app-errors.js
@@ -50,7 +50,7 @@ export function removeErrorHandler(handler) {
 export function formatErrorMessage(code, msg, ...args) {
   return `single-spa minified message #${code}: ${
     msg ? msg + " " : ""
-  }See https://single-spa.js.org/error?code=${code}${
+  }See https://single-spa.js.org/error/?code=${code}${
     args.length ? `&arg=${args.join("&arg=")}` : ""
   }`;
 }


### PR DESCRIPTION
Docusaurus doesn't like urls that don't end in `/`.

See https://github.com/CanopyTax/single-spa.js.org/issues/108#issuecomment-563927431