### PR TITLE
Small improvements to error messages

### DIFF
--- a/spec/apis/register-application.spec.js
+++ b/spec/apis/register-application.spec.js
@@ -21,12 +21,12 @@ describe("registerApplication", function() {
       expect(() => {
         singleSpa.registerApplication(app);
       }).toThrowError(
-        `The first argument must be a non-empty string 'appName'`
+        `The first argument to registerApplication must be a non-empty string 'appName'`
       );
       expect(() => {
         singleSpa.registerApplication("");
       }).toThrowError(
-        `The first argument must be a non-empty string 'appName'`
+        `The first argument to registerApplication must be a non-empty string 'appName'`
       );
     });
 
@@ -55,7 +55,7 @@ describe("registerApplication", function() {
           "no-loading-fn-will-throw-error-app",
           app
         );
-      }).toThrowError(`The activeWhen argument must be a function`);
+      }).toThrowError(`The activityFunction argument must be a function`);
     });
 
     it(`should throw an error when the activity Function isn't a function`, () => {
@@ -65,7 +65,7 @@ describe("registerApplication", function() {
           app,
           app
         );
-      }).toThrowError(`The activeWhen argument must be a function`);
+      }).toThrowError(`The activityFunction argument must be a function`);
     });
   });
 

--- a/src/applications/apps.js
+++ b/src/applications/apps.js
@@ -51,7 +51,8 @@ export function registerApplication(
     throw Error(
       formatErrorMessage(
         20,
-        __DEV__ && `The first argument must be a non-empty string 'appName'`
+        __DEV__ &&
+          `The first argument to registerApplication must be a non-empty string 'appName'`
       )
     );
   if (getAppNames().indexOf(appName) !== -1)
@@ -88,7 +89,7 @@ export function registerApplication(
     throw Error(
       formatErrorMessage(
         24,
-        __DEV__ && `The activeWhen argument must be a function`
+        __DEV__ && `The activityFunction argument must be a function`
       )
     );
 

--- a/src/navigation/navigation-events.js
+++ b/src/navigation/navigation-events.js
@@ -33,7 +33,7 @@ export function navigateToUrl(obj) {
       formatErrorMessage(
         14,
         __DEV__ &&
-          `singleSpaNavigate must be either called with a string url, with an <a> tag as its context, or with an event whose currentTarget is an <a> tag`
+          `singleSpaNavigate/navigateToUrl must be either called with a string url, with an <a> tag as its context, or with an event whose currentTarget is an <a> tag`
       )
     );
   }


### PR DESCRIPTION
Found these as I was writing documentation for the error codes. The error messages were using older terminology, such as `activeWhen`, "declare" applications (instead of register), etc.